### PR TITLE
fixed custom decimal point and float bug

### DIFF
--- a/jquery.number.js
+++ b/jquery.number.js
@@ -367,7 +367,7 @@
 	    				
 	    				// Re-format the textarea.
 	    				$this.val($this.val());
-	    				
+
 	    				if( decimals > 0 )
 	    				{
 		    				// If we haven't marked this item as 'initialised'
@@ -529,7 +529,7 @@
 			num = +(el.value
 				.replace( data.regex_dec_num, '' )
 				.replace( data.regex_dec, '.' ));
-			
+		
 			// If we've got a finite number, return it.
 			// Otherwise, simply return 0.
 			// Return as a string... thats what we're
@@ -597,7 +597,6 @@
 	 * @return string : The formatted number as a string.
 	 */
 	$.number = function( number, decimals, dec_point, thousands_sep ){
-		
 		// Set the default values here, instead so we can use them in the replace below.
 		thousands_sep	= (typeof thousands_sep === 'undefined') ? ',' : thousands_sep;
 		dec_point		= (typeof dec_point === 'undefined') ? '.' : dec_point;
@@ -609,6 +608,7 @@
 		
 		// Fix the number, so that it's an actual number.
 		number = (number + '')
+			.replace('\.', dec_point) // because the number if passed in as a float (having . as decimal point per definition) we need to replace this with the passed in decimal point character
 			.replace(new RegExp(u_sep,'g'),'')
 			.replace(new RegExp(u_dec,'g'),'.')
 			.replace(new RegExp('[^0-9+\-Ee.]','g'),'');


### PR DESCRIPTION
Here's my attempt to describe the issue that have been fixed in this pull-request:

I have a page with two input fields. The fields are bootstrapped with jquery.number like this:

```
$('.currency-format').number( true, 2 , ',', '.' );
$('.currency-format-us').number( true, 2 );
```

To explain in words what I'm trying to do:

The first field "currency-format" needs to format numbers using "." (punctuation) as a thousand separator and "," (comma) as the decimal point character.

The second field "currency-format-us" needs to format numbers using a default us-currency format - meaning "," (comma) as the thousand separator and "." (punctuation) as the decimal point character.

**Expected result:**

First field: 1.234,99
Second field: 1,234.99

**Actual result:**

First field: 123.499,00 **<- incorrect!**
Second field: 1,234.99 <- correct!

The $.number method was accepting a float as the first parameter, meaning that an input of 123,99 in the "currency-format"-field would always be formatted as "123.99" rendering my custom decimal point and thousand separators irrelevant.

I've made a minor fix which will make sure that the decimal point separator is initially replaced with a custom one.

---

I hope this made sense. Not the easiest issue to explain. I tried to make a jsfiddle demo, but was unable to include this particular version of the plugin in the example. Although it's not a working example, I have saved it anyway. The only thing needed to demonstrate the issue is to include the missing jquery.number plugin in this particular version.

[Incomplete JSFiddle example](http://jsfiddle.net/jPPSW/)

Best regards
Brian
