### PR TITLE
Proposed fix for issue #36

### DIFF
--- a/jquery.number.js
+++ b/jquery.number.js
@@ -400,7 +400,7 @@
 	    					setPos;
 	    				    				    			
 	    				// Stop executing if the user didn't type a number key, a decimal, or a comma.
-	    				if( this.value === '' || (code < 48 || code > 57) && (code < 96 || code > 105 ) && code !== 8 ) return;
+	    				if( this.value === '' || (code < 48 || code > 57) && (code < 96 || code > 105 ) && code !== 8 && code !== 110 ) return;
 	    				
 	    				// Re-format the textarea.
 	    				$this.val($this.val());


### PR DESCRIPTION
This is my solution for issue #36 (decimal point on numpad not working).
The keycode for the numpad decimal point was translated to the keycode for "delete". I removed the translation because in IE, FF and chrome the key on the numpad gives the keycode for "decimal point" when the numlock is on, and delete when it is off.

Further down, I added an extra if-condition to translate the decimal point key to whatever character has been set as the decimal separator.
