### PR TITLE
Always reset cursor position

### DIFF
--- a/jquery.number.js
+++ b/jquery.number.js
@@ -255,7 +255,7 @@
 		    					data.init = (decimals>0?1:0);
 		    					data.c = (decimals>0?-(decimals+1):0);
 		    				}
-		    				else if( this.value.length === 0 )
+		    				else
 		    				{
 		    					// Reset the cursor position.
 		    					data.init = (decimals>0?-1:0);


### PR DESCRIPTION
If all the context of a input field are selected, always reset the cursor position.
e.g. When the cursor is between the second and third decimal place, and the user presses Ctrl+A, and then types in a number. In that case the cursor should not stay between the second and third decimal place: it should be moved to just before the decimal point.
