### PR TITLE
Another fix for Issue #9

### DIFF
--- a/jquery.number.js
+++ b/jquery.number.js
@@ -273,7 +273,7 @@
 							else
 							{
 								// Reset the cursor position.
-								data.init = (decimals>0?-1:0);
+								data.init = (decimals>0?1:0);
 								data.c = (decimals>0?-(decimals):0);
 							}
 						}


### PR DESCRIPTION
Previously when typing a number such as 0.12 the cursor would jump to the start - this resolves the issue, and doesn't appear to have any negative effects.
