### PR TITLE
Fixed troubles with cursor position when type 0.** numbers

### DIFF
--- a/jquery.number.js
+++ b/jquery.number.js
@@ -237,7 +237,7 @@
 						}
 
 						// The whole lot has been selected, or if the field is empty...
-						if( start == 0 && end == this.value.length || $this.val() == 0 )
+						if( start == 0 && end == this.value.length ) //|| $this.val() == 0 )
 						{
 							if( code == 8 )		// Backspace
 							{


### PR DESCRIPTION
Fixed trouble that you can see in video bellow:
http://screencast.com/t/S2Q195bHd3Ts

When i enter number less then 1, i have troubles with position of 2-nd digit after "."
Plugin was initialized as $(".price-formatted").number(true, 4);